### PR TITLE
utilize manual list of httpreleasefeeds, etc

### DIFF
--- a/Sparkle-MITM-Vuln-Apps.py
+++ b/Sparkle-MITM-Vuln-Apps.py
@@ -20,7 +20,12 @@ def get_vulnapps():
     sparkle_info = '/Contents/Frameworks/Sparkle.framework/Versions/A/Resources/Info.plist'
     app_info = '/Contents/Info.plist'
     vulnerableapp_list = []
+    sparkle_version = None
     for app in apps.splitlines():
+        bundle_id = CFPreferencesCopyAppValue('CFBundleIdentifier',
+                                                     app + app_info)
+        sparkle_feed_url = CFPreferencesCopyAppValue('SUFeedURL',
+                                                     app + app_info)
         # If the app has a sparkle framework
         if os.path.exists(app + sparkle_info):
             # Try to get a version out of Sparkle's framework, returns None without exception if missing
@@ -29,20 +34,49 @@ def get_vulnapps():
             if not sparkle_version:
                 sparkle_version = CFPreferencesCopyAppValue('CFBundleVersion',
                                                             app + sparkle_info)
-            # Check for a SUFeedURL
-            sparkle_feed_url = CFPreferencesCopyAppValue('SUFeedURL',
-                                                         app + app_info)
-            bundle_id = CFPreferencesCopyAppValue('CFBundleIdentifier',
-                                                         app + app_info)
             # If we have a SUFeedURL
-            if sparkle_feed_url and not sparkle_feed_url.startswith('https://'):
-                # If Sparkle version is less than 1.13.1 & SUFeedURL is http
-                if not sparkle_version:
-                    vulnerableapp_list.append(app + ' - ' + bundle_id)
-                elif LooseVersion(sparkle_version) < LooseVersion('1.13.1'):
-                    vulnerableapp_list.append(app + ' - ' + bundle_id)
+        if sparkle_feed_url and not sparkle_feed_url.startswith('https://'):
+            # If Sparkle version is less than 1.13.1 & SUFeedURL is http
+            if not sparkle_version:
+                vulnerableapp_list.append(app + ' - ' + bundle_id)
+            elif LooseVersion(sparkle_version) < LooseVersion('1.13.1'):
+                vulnerableapp_list.append(app + ' - ' + bundle_id)
+        elif sparkle_feed_url and bundle_id:
+            # Leverage the list in the badnoteurl_checker function
+            if badnoteurl_checker(bundle_id.split('.')[-1]):
+                vulnerableapp_list.append(app + ' - ' + bundle_id)
     return vulnerableapp_list
 
+
+def badnoteurl_checker(app):
+    """Manually generated list of apps with HTTPS update feeds, but http release notes"""
+    bad_list = ['alternote', 'audio editor', 'auganizer', 'automatic', 'bee',
+                'betterzip', 'boxer', 'cashculator', 'chat', 'clusters',
+                'colorschemer studio', 'connected desktop', 'connector',
+                'controllermate', 'dewdrop', 'doitim', 'doubletwist',
+                'fauxpas', 'festify', 'find any file', 'findings',
+                'fivedetails flow', 'flavours', 'flexiglass', 'frizzix',
+                'fstream', 'gas mask', 'gawker', 'geekbench', 'gisto',
+                'gitbox', 'grabbox', 'hopper disassembler', 'icolors',
+                'intensify', 'invisor', 'ipalette', 'irip', 'iupx', 'juicephone',
+                'language switcher', 'latexit', 'lifeslice', 'macaw', 'machg',
+                'mactracker', 'manico', 'marked', 'minitube',
+                'miro video converter', 'moneywell', 'mou', 'musictube',
+                'musique', 'near lock', 'notational velocity', 'nvalt', 'opacity',
+                'optimal layout', 'papers', 'pester', 'picturesque', 'pins',
+                'plotdevice', 'pomotodo', 'preen', 'proxpn', 'quickcal', 'reveal',
+                'ringtones', 'rowmote helper', 'rubitrack', 'runtastic', 'sidplay',
+                'simpholders', 'slimbatterymonitor', 'smaller', 'smoothmouse',
+                'snapheal pro', 'sparkbox', 'spillo', 'stretchlink', 'textbar',
+                'thisservice', 'toau', 'totals', 'transporter desktop', 'trickster',
+                'ubar', 'vico', 'vienna', 'vimediamanager', 'vlc',
+                'vox preferences pane', 'wasted', 'wedge', 'whatsize', 'whiskey',
+                'xact', 'xmplify'
+                ]
+    if app.lower() in bad_list:
+        return True
+    else:
+        return False
 
 def main():
     """For EA, print list of all vulnerable apps including file paths"""


### PR DESCRIPTION
Ordering was screwy - we should be checking for a SUFeedURL(, and may as well get bundle ID while we're there,) BEFORE we worry about the location of the framework, since all sparkle apps (like devmate ones, I think) don't put the framework at that path we were expecting anyway. 
This errs on the side of "if I can't find the sparkle path to validate the version, just lump it in and let god sort 'em out". 

Also checking the ~100 apps that use https feeds but http RELEASE NOTES URLs.